### PR TITLE
fix sidebar transition

### DIFF
--- a/src/components/Navigation/SideDrawer/SideDrawer.css
+++ b/src/components/Navigation/SideDrawer/SideDrawer.css
@@ -11,12 +11,11 @@
   box-sizing: border-box;
   transition: transform 0.3s ease;
   transform: translateX(-100%);
-
+  background-color: black;
 }
 
 .SideDrawer.Open {
   transform: translateX(0);
-  background-color: black;
 }
 
 @media (min-width: 500px) {

--- a/src/components/Navigation/SideDrawer/SideDrawer.js
+++ b/src/components/Navigation/SideDrawer/SideDrawer.js
@@ -10,27 +10,27 @@ class SideDrawer extends Component {
   render() {
     let sideDrawerClass = [classes.SideDrawer];
     // SideDrawer will now be an array  with the side drawer classes and the open class
-    sideDrawerClass.push(classes.Open);
+    if (this.props.showSideDrawer) {
+      sideDrawerClass.push(classes.Open);
+    }
     return (
       <Aux classname={classes.SideDrawer}>
         <Backdrop
           showBackdrop={this.props.showSideDrawer}
           clicked={this.props.toggleSideDrawer}
         />
-        {this.props.showSideDrawer && (
-          <div
-            className={sideDrawerClass.join(" ")}
-            onClick={this.props.toggleSideDrawer}
-          >
-            <div className={classes.Logo}>
-              <Logo />
-            </div>
-
-            <nav>
-              <NavigationItems />
-            </nav>
+        <div
+          className={sideDrawerClass.join(" ")}
+          onClick={this.props.toggleSideDrawer}
+        >
+          <div className={classes.Logo}>
+            <Logo />
           </div>
-        )}
+
+          <nav>
+            <NavigationItems />
+          </nav>
+        </div>
       </Aux>
     );
   }


### PR DESCRIPTION
The problem is that you **render** the drawer only when `showSideDrawer` so before it becomes true, the sidebar is not in the DOM yet so the transition is not affecting it.

The solution is to keep it in the DOM all the time but toggle `. Open` class to change the style.

There are libraries that knows to make the transition works even for elements that are not in the DOM but it's a bit more complicated.